### PR TITLE
small change to compile on latest Arduino 1.5.7

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -15,6 +15,8 @@
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 #include <avr/pgmspace.h>
+    // next line per http://postwarrior.com/arduino-ethershield-error-prog_char-does-not-name-a-type/
+#define prog_char  char PROGMEM
 
 #if (ARDUINO >= 100)
  #include "Arduino.h"


### PR DESCRIPTION
I was unable to get this library to compile with the latest Arduino (1.5.7) - per this page, it appears as though the compiler changed slightly: http://postwarrior.com/arduino-ethershield-error-prog_char-does-not-name-a-type/

The change here works for me, I'm able to compile and use Arduino to run the example sketch...
