### PR TITLE
Enable https redirect support and get IMEI

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -112,6 +112,20 @@ uint8_t Adafruit_FONA::getSIMCCID(char *ccid) {
    return strlen(ccid);
 }
 
+/********* IMEI **********************************************************/
+
+uint8_t Adafruit_FONA::getIMEI(char *imei) {
+    getReply("AT+GSN");
+
+   // up to 15 chars
+   strncpy(imei, replybuffer, 15);
+   imei[15] = 0;
+
+   readline(); // eat 'OK'
+
+   return strlen(imei);
+}
+
 /********* NETWORK *******************************************************/
 
 uint8_t Adafruit_FONA::getNetworkStatus(void) {
@@ -444,6 +458,15 @@ boolean Adafruit_FONA::HTTP_GET_start(char *url,
   if (strcmp(replybuffer, "OK") != 0)
     return false;
 
+  // HTTPS redirect
+  if (httpsredirect) {
+    if (! sendCheckReply(F("AT+HTTPPARA=\"REDIR\",1"), F("OK")))
+      return false;
+
+    if (! sendCheckReply(F("AT+HTTPSSL=1"), F("OK")))
+      return false;
+  }
+
   // HTTP GET
   if (! sendCheckReply(F("AT+HTTPACTION=0"), F("OK")))
     return false;
@@ -465,6 +488,10 @@ boolean Adafruit_FONA::HTTP_GET_start(char *url,
 boolean Adafruit_FONA::HTTP_GET_end(void) {
   flushInput();
   sendCheckReply(F("AT+HTTPTERM"), F("OK"));
+}
+
+void Adafruit_FONA::setHTTPSRedirect(boolean onoff) {
+  httpsredirect = onoff;
 }
 
 /********* LOW LEVEL *******************************************/

--- a/Adafruit_FONA.h
+++ b/Adafruit_FONA.h
@@ -70,6 +70,9 @@ class Adafruit_FONA : public Stream {
   uint8_t getNetworkStatus(void);
   uint8_t getRSSI(void);
 
+  // IMEI
+  uint8_t getIMEI(char *imei);
+
   // set Audio output
   boolean setAudio(uint8_t a);
   boolean setVolume(uint8_t i);
@@ -100,6 +103,9 @@ class Adafruit_FONA : public Stream {
   boolean HTTP_GET_start(char *url, uint16_t *status, uint16_t *datalen);
   boolean HTTP_GET_end(void);
 
+  // HTTPS
+  void setHTTPSRedirect(boolean onoff);
+
   // PWM (buzzer)
   boolean PWM(uint16_t period, uint8_t duty = 50);
 
@@ -114,6 +120,7 @@ class Adafruit_FONA : public Stream {
   const __FlashStringHelper *apn;
   const __FlashStringHelper *apnusername;
   const __FlashStringHelper *apnpassword;
+  boolean httpsredirect;
 
   void flushInput();
   uint16_t readRaw(uint16_t b);


### PR DESCRIPTION
Enable support for https redirect, for example:
http://www.gmail.com -> https://www.gmail.com

Added ability to retrieve module IMEI.
