### PR TITLE
Return false, rather than -1 for boolean functions.

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -560,7 +560,7 @@ boolean Adafruit_FONA::getSMSSender(uint8_t i, char *sender, int senderlen) {
 }
 
 boolean Adafruit_FONA::sendSMS(char *smsaddr, char *smsmsg) {
-  if (! sendCheckReply(F("AT+CMGF=1"), ok_reply)) return -1;
+  if (! sendCheckReply(F("AT+CMGF=1"), ok_reply)) return false;
 
   char sendcmd[30] = "AT+CMGS=\"";
   strncpy(sendcmd+9, smsaddr, 30-9-2);  // 9 bytes beginning, 2 bytes for close quote + null
@@ -600,7 +600,7 @@ boolean Adafruit_FONA::sendSMS(char *smsaddr, char *smsmsg) {
 
 
 boolean Adafruit_FONA::deleteSMS(uint8_t i) {
-    if (! sendCheckReply(F("AT+CMGF=1"), ok_reply)) return -1;
+    if (! sendCheckReply(F("AT+CMGF=1"), ok_reply)) return false;
   // read an sms
   char sendbuff[12] = "AT+CMGD=000";
   sendbuff[8] = (i / 100) + '0';
@@ -615,7 +615,7 @@ boolean Adafruit_FONA::deleteSMS(uint8_t i) {
 /********* USSD *********************************************************/
 
 boolean Adafruit_FONA::sendUSSD(char *ussdmsg, char *ussdbuff, uint16_t maxlen, uint16_t *readlen) {
-  if (! sendCheckReply(F("AT+CUSD=1"), ok_reply)) return -1;
+  if (! sendCheckReply(F("AT+CUSD=1"), ok_reply)) return false;
 
   char sendcmd[30] = "AT+CUSD=1,\"";
   strncpy(sendcmd+11, ussdmsg, 30-11-2);  // 11 bytes beginning, 2 bytes for close quote + null


### PR DESCRIPTION
When running code like this:

```cpp
        if (!fona.sendSMS(number,message)) {
          Serial.println(F("Failed"));
        } else {
          Serial.println(F("Sent!"));
        }
```

... the function will evaluate to true, even though it was actually a failure.

Using boolean values (matching the return type), rather than a `-1` fixes this. 