### PR TITLE
fixed getNumSMS() for FONA 3G

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -475,6 +475,9 @@ int8_t Adafruit_FONA::getNumSMS(void) {
     return numsms;
   if (sendParseReply(F("AT+CPMS?"), F("\"SM_P\","), &numsms)) 
     return numsms;
+  // handling for the FONA 3G
+  if (sendParseReply(F("AT+CPMS?"), F("\"ME\","), &numsms)) 
+    return numsms;
   return -1;
 }
 


### PR DESCRIPTION
Depending on the [FONA 3G FAQ](https://learn.adafruit.com/adafruit-fona-3g-cellular-gps-breakout/3g-vs-fona-800-808#sms-number-query-reply-is-different) I adjusted the getNumSMS method to get the library working with the FONA 3G board. 

Alternatively the method could be overwritten in the Adafruit_FONA_3G class. If this is preferred just let me know.
