### PR TITLE
Added getOperator()

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -227,6 +227,18 @@ uint8_t Adafruit_FONA::getIMEI(char *imei) {
   return strlen(imei);
 }
 
+/********* OPERATOR *******************************************************/
+bool Adafruit_FONA::getOperator(char *op, uint8_t oplen) {
+  DEBUG_PRINT(F("\t---> ")); DEBUG_PRINTLN(F("AT+COPS?"));
+  mySerial->println(F("AT+COPS?"));
+  readline(1000);
+  DEBUG_PRINT(F("\t<--- ")); DEBUG_PRINTLN(replybuffer);
+  boolean result = parseReplyQuoted(F("+COPS:"), op, oplen, ',', 2);
+  if (!result) op[0] ='\0';
+  flushInput();
+  return result;
+}
+
 /********* NETWORK *******************************************************/
 
 uint8_t Adafruit_FONA::getNetworkStatus(void) {

--- a/Adafruit_FONA.h
+++ b/Adafruit_FONA.h
@@ -97,6 +97,7 @@ class Adafruit_FONA : public FONAStreamType {
 
   // IMEI
   uint8_t getIMEI(char *imei);
+  bool getOperator(char *op, uint8_t oplen);
 
   // set Audio output
   boolean setAudio(uint8_t a);


### PR DESCRIPTION
Added a simple getOperator() method.
To be nice to memory, a length argument is passed to limit the number of bytes passed from the SIM800 operator string to the calling program.
