### PR TITLE
cast char * to unsigned char* in Afafruit_FONA:TCPsend so will compile

### DIFF
--- a/Adafruit_FONA.h
+++ b/Adafruit_FONA.h
@@ -250,6 +250,11 @@ class Adafruit_FONA_3G : public Adafruit_FONA {
     boolean pickUp(void);
     boolean enableGPRS(boolean onoff);
     boolean enableGPS(boolean onoff);
+    boolean netOpen();
+    boolean netClose();
+    boolean TCPconnect(uint8_t conn, char *server, uint16_t port);
+    boolean TCPclose(uint8_t conn);
+    boolean TCPsend(uint8_t conn, char *packet, uint8_t len);
 
  protected:
     boolean parseReply(FONAFlashStringPtr toreply,


### PR DESCRIPTION
 	cast char * to unsigned char* in Adafruit_FONA:TCPsend so will compile

add some basic TCP functions for the 3G version (including fix above)
I found on my 3G FONA the TCP AT commands seem quite different and have extra functionality (multiple connections for starters), so I have adapted some functions to allow some TCP functionality.