### PR TITLE
Allow compilation on ESP8266

### DIFF
--- a/includes/platform/FONAPlatStd.h
+++ b/includes/platform/FONAPlatStd.h
@@ -37,8 +37,11 @@
   #include <NewSoftSerial.h>
 #endif
 
-#include <avr/pgmspace.h>
-
+#if (defined(__AVR__))
+#include <avr\pgmspace.h>
+#else
+#include <pgmspace.h>
+#endif
 
 // DebugStream	sets the Stream output to use
 // for debug (only applies when ADAFRUIT_FONA_DEBUG

--- a/includes/platform/FONAPlatStd.h
+++ b/includes/platform/FONAPlatStd.h
@@ -38,8 +38,8 @@
 #endif
 
 #if (defined(__AVR__))
-#include <avr\pgmspace.h>
-#else
+#include <avr/pgmspace.h>
+#elif (defined(ESP8266))
 #include <pgmspace.h>
 #endif
 


### PR DESCRIPTION
With this addition, library now compiles on ESP8266.