### PR TITLE
Two bug fixes: TCPsend argument type, and missing end-of-buffer check

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -1755,12 +1755,7 @@ uint8_t Adafruit_FONA::readline(uint16_t timeout, boolean multiline) {
   uint16_t replyidx = 0;
 
   while (timeout--) {
-    if (replyidx >= 254) {
-      //DEBUG_PRINTLN(F("SPACE"));
-      break;
-    }
-
-    while(mySerial->available()) {
+    while(replyidx < sizeof(replybuffer)-1 && mySerial->available()) {
       char c =  mySerial->read();
       if (c == '\r') continue;
       if (c == 0xA) {

--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -1384,7 +1384,7 @@ boolean Adafruit_FONA::TCPconnected(void) {
   return (strcmp(replybuffer, "STATE: CONNECT OK") == 0);
 }
 
-boolean Adafruit_FONA::TCPsend(char *packet, uint8_t len) {
+boolean Adafruit_FONA::TCPsend(uint8_t *packet, uint8_t len) {
 
   DEBUG_PRINT(F("AT+CIPSEND="));
   DEBUG_PRINTLN(len);

--- a/Adafruit_FONA.h
+++ b/Adafruit_FONA.h
@@ -146,7 +146,7 @@ class Adafruit_FONA : public FONAStreamType {
   boolean TCPconnect(char *server, uint16_t port);
   boolean TCPclose(void);
   boolean TCPconnected(void);
-  boolean TCPsend(char *packet, uint8_t len);
+  boolean TCPsend(uint8_t *packet, uint8_t len);
   uint16_t TCPavailable(void);
   uint16_t TCPread(uint8_t *buff, uint8_t len);
 


### PR DESCRIPTION
Changed argument type of TCPsend from char * to uint8_t *. Without this change, compilation failed on type incompatibility in the arduino.cc IDE version 2:1.0.5+dfsg2-4 (as distributed with Debian Jessie), when compiling for Arduino UNO. I guess the incompatibility is because of the signed/unsigned difference.

Moved the end-of-buffer check from the outer loop to the inner loop in readline(): this is necessary, because the inner loop is capable of traversing through the buffer. Also, use sizeof() to determine the end of buffer, like in readRaw().

Tested superficially by compiling and running this together with my own sketch code. I verified that this compiles without warnings, and I can communicate with my FONA (fona.begin() and fona.unlockSIM() are successful).
