### PR TITLE
Added getBusy()

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -254,6 +254,15 @@ uint8_t Adafruit_FONA::getRSSI(void) {
   return reply;
 }
 
+uint8_t Adafruit_FONA::getBusy(void) {
+  uint16_t reply;
+
+  if (! sendParseReply(F("AT+GSMBUSY?"), F("+GSMBUSY: "), &reply) ) return 0;
+
+  return reply;
+}
+
+
 /********* AUDIO *******************************************************/
 
 boolean Adafruit_FONA::setAudio(uint8_t a) {

--- a/Adafruit_FONA.h
+++ b/Adafruit_FONA.h
@@ -97,6 +97,7 @@ class Adafruit_FONA : public FONAStreamType {
   uint8_t getSIMCCID(char *ccid);
   uint8_t getNetworkStatus(void);
   uint8_t getRSSI(void);
+  uint8_t getBusy(void);
 
   // IMEI
   uint8_t getIMEI(char *imei);


### PR DESCRIPTION
Added getBusy() method to check whether is AT+GSMBUSY set to enabled or disabled previously.
Otherwise you can reject incoming calls with AT+GSMBUSY=1 and enable it with AT+GSMBUSY=0.

Example usage:
`boolean isBusy = (fona.getBusy() == 0) ? false : true;`