### PR TITLE
set Baudrate

### DIFF
--- a/Adafruit_FONA.cpp
+++ b/Adafruit_FONA.cpp
@@ -144,7 +144,7 @@ boolean Adafruit_FONA::begin(Stream &port) {
 
 
 /********* Serial port ********************************************/
-boolean Adafruit_FONA::setBaudrate(uint16_t baud) {
+boolean Adafruit_FONA::setBaudrate(uint32_t baud) {
   return sendCheckReply(F("AT+IPREX="), baud, ok_reply);
 }
 

--- a/Adafruit_FONA.h
+++ b/Adafruit_FONA.h
@@ -81,7 +81,7 @@ class Adafruit_FONA : public FONAStreamType {
   void flush();
 
   // FONA 3G requirements
-  boolean setBaudrate(uint16_t baud);
+  boolean setBaudrate(uint32_t baud);
 
   // RTC
   boolean enableRTC(uint8_t i);


### PR DESCRIPTION
Integer size was too small. Changed to uint32_t, will avoid the overflow.