### PR TITLE
Added support for Enable Network Time Sync on FONA 3G

### DIFF
--- a/Adafruit_FONA.h
+++ b/Adafruit_FONA.h
@@ -281,15 +281,20 @@ public:
   bool playToolkitTone(uint8_t t, uint16_t len);
   bool hangUp(void);
   bool pickUp(void);
+  bool enableNetworkTimeSync(bool onoff);
   bool enableGPRS(bool onoff);
   bool enableGPS(bool onoff);
 
 protected:
   bool parseReply(FONAFlashStringPtr toreply, float *f, char divider,
                   uint8_t index);
+  bool parseReply(FONAFlashStringPtr toreply, uint16_t *v, char divider,
+                  uint8_t index);
 
   bool sendParseReply(FONAFlashStringPtr tosend, FONAFlashStringPtr toreply,
                       float *f, char divider = ',', uint8_t index = 0);
+  bool sendParseReply(FONAFlashStringPtr tosend, FONAFlashStringPtr toreply,
+                      uint16_t *v, char divider = ',', uint8_t index = 0);
 };
 
 #endif

--- a/examples/FONAtest/FONAtest.ino
+++ b/examples/FONAtest/FONAtest.ino
@@ -145,7 +145,7 @@ void printMenu(void) {
   Serial.println(F("[u] Send USSD"));
   
   // Time
-  Serial.println(F("[y] Enable network time sync (FONA 800 & 808)"));
+  Serial.println(F("[y] Enable network time sync"));
   Serial.println(F("[Y] Enable NTP time sync (GPRS FONA 800 & 808)"));
   Serial.println(F("[t] Get network time"));
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit FONA Library
-version=1.3.6
+version=1.3.7
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the Adafruit FONA


### PR DESCRIPTION
This PR resolves https://github.com/adafruit/Adafruit_FONA/issues/114 by adding support to Enable Network Time Sync for the FONA 3G.

This is already supported for the FONA 808 and FONA 800, but did not previously support the FONA 3G as enabling it required different AT commands.